### PR TITLE
added 18-char limit to project descrip in dashboard cards

### DIFF
--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -41,7 +41,13 @@
           <strong><p><%= project.title %></p></strong>
         </div>
         <div class="dash-card-section">
-          <p><%= project.description %></p>
+          <p>
+            <% if project.description.length > 18 %>
+              <%= project.description[0..17] + "..." %>
+            <% else %>
+              <%= project.description %>
+            <% end %>
+          </p>
         </div>
         <div class="dash-card-section">
           <p><%= project.media_type %></p>


### PR DESCRIPTION
char-limit to prevent text wrapping causing projects with long descriptions from making cards longer
<img width="675" alt="Screen Shot 2020-03-05 at 8 23 30 PM" src="https://user-images.githubusercontent.com/50847314/76022704-8f3d3700-5f1f-11ea-9435-e35a3d1ea809.png">

18-char limit to take into account on widest characters e.g.
<img width="631" alt="Screen Shot 2020-03-05 at 8 23 51 PM" src="https://user-images.githubusercontent.com/50847314/76022717-95cbae80-5f1f-11ea-999e-67c15f8ea782.png">
