### PR TITLE
adjust "Message Me" button color when user is not signed in, now aligns with btn-box-dark

### DIFF
--- a/app/assets/stylesheets/pages/_project-show.scss
+++ b/app/assets/stylesheets/pages/_project-show.scss
@@ -101,7 +101,7 @@
   padding-bottom: 20px;
   border-bottom: 1px solid $gray;
   a {
-    color: inherit;
+    color: $white;
     &:hover {
       text-decoration: none;
     }


### PR DESCRIPTION
Button text, when not logged in, used to inherit color from anchor tag default (black). It now aligns with the btn-box-dark styling.

Before:
![Screen Shot 2020-05-05 at 4 48 29 PM](https://user-images.githubusercontent.com/50847314/81119539-96b59800-8ef0-11ea-834b-5e0fc8cd806b.png)

After: 
![Screen Shot 2020-05-05 at 4 49 23 PM](https://user-images.githubusercontent.com/50847314/81119548-9d440f80-8ef0-11ea-8733-aeaf322688d3.png)
